### PR TITLE
add names package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/aws-controllers-k8s/pkg
 go 1.18
 
 require (
+	github.com/dlclark/regexp2 v1.4.0
+	github.com/iancoleman/strcase v0.2.0
 	github.com/stretchr/testify v1.7.1
 	k8s.io/apimachinery v0.23.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -59,6 +61,8 @@ github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97Dwqy
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=

--- a/names/names.go
+++ b/names/names.go
@@ -1,0 +1,344 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package names
+
+import (
+	"regexp"
+	"strings"
+
+	re2 "github.com/dlclark/regexp2" // for negative lookahead support
+	"github.com/iancoleman/strcase"
+
+	"github.com/aws-controllers-k8s/pkg/strutil"
+)
+
+var (
+	nonAlphaNumRegexp *regexp.Regexp = regexp.MustCompile("[^a-zA-Z0-9]+")
+)
+
+type initialismTranslator struct {
+	// CamelCased initialism, e.g. Tls
+	camel string
+	// Uppercase representation of the initialism
+	upper string
+	// Lowercase representation of the initialism
+	lower string
+	// Regular expression matching the initialism within a subject string.
+	// Usually nil, unless the camel-cased initialism is a series of characters
+	// that is commonly confused with a longer form of the initialism (e.g. for
+	// "Id", we don't want to match "Identifier")
+	re *re2.Regexp
+}
+
+var (
+	// NOTE(jaypipes): these are ordered. Some things need to be processed
+	// before others. For example, we need to process "Dbi" before "Db"
+	initialisms = []initialismTranslator{
+		// Special... even though IDS is a valid initialism, in AWS APIs, the
+		// camel-cased "Ids" refers to a set of Identifiers, so the correct
+		// uppercase representation is "IDs"
+		{"Ids", "IDs", "ids", nil},
+		// Need to prevent "Identifier" from becoming "IDentifier",
+		// and "Idle" from becoming "IDle"
+		{"Id", "ID", "id", re2.MustCompile("Id(?!entifier|le|entity)", re2.None)},
+		// Need to prevent "DbInstance" from becoming "dbinstance" when lower
+		// prefix-converted (should be dbInstance). Amazingly, even within just
+		// the RDS API, there are fields named "DbiResourceId",
+		// "DBInstanceIdentifier" and "DbInstanceIdentifier" (note the
+		// capitalization differences). This transformer handles this
+		// problematic scenario and matches only the "Dbi" case-sensitive
+		// expression and converts it to "DBI" or "dbi" depending on whether
+		// the initialism appears at the start of the name
+		{"Dbi", "DBI", "dbi", re2.MustCompile("Dbi", re2.None)},
+		{"Db", "DB", "db", re2.MustCompile("Db(?!i)", re2.None)},
+		{"Db", "DB", "db", re2.MustCompile("DB", re2.None)},
+		// Prevent "CACertificateIdentifier" from becoming
+		// "cACertificateIdentifier when lower prefix-converted (should be
+		// "caCertificateIdentifier")
+		{"CACert", "CACert", "caCert", re2.MustCompile("CACert", re2.None)},
+		// Prevent "MD5OfBody" from becoming "MD5OfBody" when lower
+		// prefix-converted (should be "md5OfBody")
+		{"MD5Of", "MD5Of", "md5Of", re2.MustCompile("M[dD]5Of", re2.None)},
+		// Prevent "MultipartUpload" from becoming "MultIPartUpload"
+		{"Ip", "IP", "ip", re2.MustCompile("Ip(?!art)", re2.None)},
+		// Model fields containing AMI will always capitalize the 'A' hence we don't
+		// have to look for words starting with a lowercase 'A'
+		{"Amis", "AMIs", "amis", re2.MustCompile("Amis", re2.None)},
+		{"Ami", "AMI", "ami", re2.MustCompile("Ami", re2.None)},
+		// Easy find-and-replacements...
+		{"Acl", "ACL", "acl", nil},
+		{"Acp", "ACP", "acp", nil},
+		{"Api", "API", "api", nil},
+		{"Arn", "ARN", "arn", nil},
+		{"Asn", "ASN", "asn", nil},
+		{"Aws", "AWS", "aws", nil},
+		{"Az", "AZ", "az", nil},
+		{"Bgp", "BGP", "bgp", nil},
+		{"Cors", "CORS", "cors", nil},
+		{"Cidr", "CIDR", "cidr", nil},
+		{"Cname", "CNAME", "cname", nil},
+		{"Cpu", "CPU", "cpu", nil},
+		{"Crl", "CRL", "crl", nil},
+		{"Cps", "CPS", "cps", nil},
+		{"Csr", "CSR", "csr", nil},
+		{"Dhcp", "DHCP", "dhcp", nil},
+		{"Dns", "DNS", "dns", nil},
+		{"Dpd", "DPD", "dpd", nil},
+		{"Ebs", "EBS", "ebs", nil},
+		{"Ec2", "EC2", "ec2", nil},
+		{"Ecr", "ECR", "ecr", nil},
+		// Prevent "Edit" from becoming "EDIt"
+		{"Edi", "EDI", "edi", re2.MustCompile("Edi(?!t)", re2.None)},
+		{"Efs", "EFS", "efs", nil},
+		{"Eks", "EKS", "eks", nil},
+		// Prevent "Enable" and "Enabling" from becoming "ENAble"
+		{"Ena", "ENA", "ena", re2.MustCompile("Ena(?!bl)", re2.None)},
+		{"Ecmp", "ECMP", "ecmp", nil},
+		{"Fpga", "FPGA", "fpga", nil},
+		{"Gpu", "GPU", "gpu", nil},
+		{"Html", "HTML", "html", nil},
+		{"Http", "HTTP", "http", nil},
+		{"Https", "HTTPS", "https", nil},
+		{"Iam", "IAM", "iam", nil},
+		{"Icmp", "ICMP", "icmp", nil},
+		// Prevent "IOPS" from becoming "IOps"
+		{"Io", "IO", "io", re2.MustCompile("Io(?!ps)", re2.None)},
+		{"Iops", "IOPS", "iops", nil},
+		{"Json", "JSON", "json", nil},
+		{"Jwt", "JWT", "jwt", nil},
+		{"Kms", "KMS", "kms", nil},
+		{"Ldap", "LDAP", "ldap", nil},
+		{"Mfa", "MFA", "mfa", nil},
+		// Prevent "Native" from becoming "NATive"
+		{"Nat", "NAT", "nat", re2.MustCompile("Nat(?!i)", re2.None)},
+		{"Oidc", "OIDC", "oidc", nil},
+		{"Ocsp", "OCSP", "ocsp", nil},
+		// Capitalize the 'd' following RAM in certain cases
+		{"Ramdisk", "RAMDisk", "ramDisk", re2.MustCompile("Ramdisk", re2.None)},
+		// Model fields starting with 'Ram' refer to RAM
+		{"Ram", "RAM", "ram", re2.MustCompile("Ram", re2.None)},
+		{"Rfc", "RFC", "rfc", nil},
+		{"Sdk", "SDK", "sdk", nil},
+		{"Sha256", "SHA256", "sha256", nil},
+		{"Sns", "SNS", "sns", nil},
+		{"Sqs", "SQS", "sqs", nil},
+		{"Sriov", "SRIOV", "sriov", nil},
+		{"Sse", "SSE", "sse", nil},
+		{"Ssl", "SSL", "ssl", nil},
+		{"Tcp", "TCP", "tcp", nil},
+		{"Tde", "TDE", "tde", nil},
+		{"Tls", "TLS", "tls", nil},
+		{"Udp", "UDP", "udp", nil},
+		// Need to prevent "security" from becoming "SecURIty"
+		{"Uri", "URI", "uri", re2.MustCompile("(?!sec)uri(?!ty)|(Uri)", re2.None)},
+		{"Url", "URL", "url", nil},
+		{"Uuid", "UUID", "uuid", nil},
+		{"Vlan", "VLAN", "vlan", nil},
+		{"Vpc", "VPC", "vpc", nil},
+		{"Vpn", "VPN", "vpn", nil},
+		{"Vgw", "VGW", "vgw", nil},
+		{"Waf", "WAF", "waf", nil},
+		{"Xml", "XML", "xml", nil},
+		{"Yaml", "YAML", "yaml", nil},
+	}
+)
+
+var goKeywords = []string{
+	"break",
+	"case",
+	"chan",
+	"const",
+	"continue",
+	"default",
+	"defer",
+	"else",
+	"fallthrough",
+	"for",
+	"func",
+	"go",
+	"goto",
+	"if",
+	"import",
+	"interface",
+	"map",
+	"package",
+	"range",
+	"return",
+	"select",
+	"struct",
+	"switch",
+	"type",
+	"var",
+}
+
+// Names contains variations of a name
+type Names struct {
+	Original      string
+	Camel         string
+	CamelLower    string
+	Lower         string
+	Snake         string
+	SnakeStripped string
+}
+
+// New returns a Names containing variations of a supplied name
+func New(original string) Names {
+	return Names{
+		Original:   original,
+		Camel:      goName(original, false, false),
+		CamelLower: goName(original, true, false),
+		Lower:      strings.ToLower(original),
+		Snake:      goName(original, false, true),
+		SnakeStripped: nonAlphaNumRegexp.ReplaceAllString(
+			goName(original, false, true), "",
+		),
+	}
+}
+
+func goName(original string, lowerFirst bool, snake bool) (result string) {
+	result = original
+	if !lowerFirst {
+		result = strcase.ToCamel(result)
+	}
+	result, err := normalizeInitialisms(result, lowerFirst, snake)
+	if err != nil {
+		panic(err)
+	}
+	if lowerFirst {
+		result, err = normalizeInitialisms(strcase.ToLowerCamel(result), lowerFirst, snake)
+		if err != nil {
+			panic(err)
+		}
+	}
+	if snake {
+		result = strcase.ToSnake(result)
+	}
+	if strutil.InStrings(result, goKeywords) {
+		result = result + "_"
+	}
+	return
+}
+
+// normalizeInitialisms takes a subject string and adapts the string according
+// to the Go best practice naming convention for initialisms.
+//
+// Examples:
+//
+//  original   | lowerFirst | output
+// ------------+ ---------- + -------------------------
+// Identifier  | true       | Identifier
+// Identifier  | false      | Identifier
+// Id          | true       | id
+// Id          | false      | ID
+// SSEKMSKeyId | true       | sseKMSKeyID
+// SSEKMSKeyId | false      | SSEKMSKeyID
+// RoleArn     | true       | roleARN
+// RoleArn     | false      | RoleARN
+//
+// See: https://github.com/golang/go/wiki/CodeReviewComments#initialisms
+func normalizeInitialisms(original string, lowerFirst bool, snake bool) (result string, err error) {
+	result = original
+	for _, initTrx := range initialisms {
+		if initTrx.re == nil {
+			if snake {
+				// If we need to snakecase, we need to look for the uppercase
+				// or lowercase initialism and replace with the lowercase
+				// initialism plus an underscore. For example, if original ==
+				// SSEKMSId and we pass snake == true, we want to return
+				// sse_kms_key_id
+				toReplace := "_" + initTrx.lower + "_"
+				result = strings.Replace(result, initTrx.lower, toReplace, -1)
+				result = strings.Replace(result, initTrx.upper, toReplace, -1)
+				continue
+			}
+			if lowerFirst && strings.Index(result, initTrx.upper) == 0 {
+				// if we need to lowercase initialisms, check to see if the
+				// initialism's capitalized form starts the string, and if so,
+				// lowercase it. For example, if we get original == SSEKMSKeyId
+				// and we pass lower == true, we want to return sseKMSKeyID
+				result = strings.Replace(result, initTrx.upper, initTrx.lower, 1)
+			}
+			// Replace CamelCased initialisms with the uppercase representation
+			// of the initialism EXCEPT when the CamelCased initialism appears
+			// at the start of the original string and we've passed a true
+			// lower parameter, in which case we lowercase just the first
+			// occurrence of the CamelCased initialism
+			pos := strings.Index(result, initTrx.camel)
+			switch pos {
+			case -1:
+				continue
+			case 0:
+				if lowerFirst {
+					toReplace := initTrx.lower
+					result = strings.Replace(result, initTrx.camel, toReplace, 1)
+				}
+				toReplace := initTrx.upper
+				if snake {
+					toReplace = "_" + toReplace + "_"
+				}
+				result = strings.Replace(result, initTrx.camel, toReplace, -1)
+			default:
+				toReplace := initTrx.upper
+				if snake {
+					toReplace = "_" + toReplace + "_"
+				}
+				result = strings.Replace(result, initTrx.camel, toReplace, -1)
+			}
+		} else {
+			match, err := initTrx.re.FindStringMatch(result)
+			if err != nil {
+				return "", err
+			}
+			if match == nil {
+				continue
+			}
+			startFrom := match.Group.Capture.Index
+			if lowerFirst {
+				if startFrom == 0 {
+					// The matched string appears at the start of the string --
+					// e.g. IdFirstElementId. In this case, if we've asked to lower
+					// the output, we need to lower only the first occurrence of
+					// the matched expression, not all of it -- e.g.
+					// idFirstElementID
+					toReplace := initTrx.lower
+					result, err = initTrx.re.Replace(result, toReplace, 0, 1)
+					if err != nil {
+						return "", err
+					}
+					match, err = initTrx.re.FindNextMatch(match)
+					if err != nil {
+						return "", nil
+					}
+					if match == nil {
+						continue
+					}
+					startFrom = match.Group.Capture.Index
+				}
+			}
+			toReplace := initTrx.upper
+			if snake {
+				toReplace = "_" + initTrx.lower + "_"
+			}
+			result, err = initTrx.re.Replace(result, toReplace, startFrom, -1)
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	if snake {
+		result = strings.Replace(result, "__", "_", -1)
+		result = strings.Trim(result, "_")
+	}
+	return result, nil
+}

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -1,0 +1,96 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package names_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws-controllers-k8s/pkg/names"
+)
+
+func TestNames(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		original            string
+		expectCamel         string
+		expectCamelLower    string
+		expectSnake         string
+		expectSnakeStripped string
+	}{
+		{"Ami", "AMI", "ami", "ami", "ami"},
+		{"AmiLaunchIndex", "AMILaunchIndex", "amiLaunchIndex", "ami_launch_index", "amilaunchindex"},
+		{"Amis", "AMIs", "amis", "amis", "amis"},
+		{"AmiType", "AMIType", "amiType", "ami_type", "amitype"},
+		{"CacheSecurityGroup", "CacheSecurityGroup", "cacheSecurityGroup", "cache_security_group", "cachesecuritygroup"},
+		{"Camila", "Camila", "camila", "camila", "camila"},
+		{"DbInstanceId", "DBInstanceID", "dbInstanceID", "db_instance_id", "dbinstanceid"},
+		{"DBInstanceId", "DBInstanceID", "dbInstanceID", "db_instance_id", "dbinstanceid"},
+		{"DBInstanceID", "DBInstanceID", "dbInstanceID", "db_instance_id", "dbinstanceid"},
+		{"DBInstanceIdentifier", "DBInstanceIdentifier", "dbInstanceIdentifier", "db_instance_identifier", "dbinstanceidentifier"},
+		{"DbiResourceId", "DBIResourceID", "dbiResourceID", "dbi_resource_id", "dbiresourceid"},
+		{"DpdTimeoutAction", "DPDTimeoutAction", "dpdTimeoutAction", "dpd_timeout_action", "dpdtimeoutaction"},
+		{"Dynamic", "Dynamic", "dynamic", "dynamic", "dynamic"},
+		{"Ecmp", "ECMP", "ecmp", "ecmp", "ecmp"},
+		{"EdiPartyName", "EDIPartyName", "ediPartyName", "edi_party_name", "edipartyname"},
+		{"Editable", "Editable", "editable", "editable", "editable"},
+		{"Ena", "ENA", "ena", "ena", "ena"},
+		{"Examine", "Examine", "examine", "examine", "examine"},
+		{"Family", "Family", "family", "family", "family"},
+		{"Id", "ID", "id", "id", "id"},
+		{"ID", "ID", "id", "id", "id"},
+		{"Identifier", "Identifier", "identifier", "identifier", "identifier"},
+		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance", "ioperformance"},
+		{"Iops", "IOPS", "iops", "iops", "iops"},
+		{"Ip", "IP", "ip", "ip", "ip"},
+		{"Frame", "Frame", "frame", "frame", "frame"},
+		{"KeyId", "KeyID", "keyID", "key_id", "keyid"},
+		{"KeyID", "KeyID", "keyID", "key_id", "keyid"},
+		{"KeyIdentifier", "KeyIdentifier", "keyIdentifier", "key_identifier", "keyidentifier"},
+		{"LdapServerMetadata", "LDAPServerMetadata", "ldapServerMetadata", "ldap_server_metadata", "ldapservermetadata"},
+		{"MaxIdleConnectionsPercent", "MaxIdleConnectionsPercent", "maxIdleConnectionsPercent", "max_idle_connections_percent", "maxidleconnectionspercent"},
+		{"MultipartUpload", "MultipartUpload", "multipartUpload", "multipart_upload", "multipartupload"},
+		{"Nat", "NAT", "nat", "nat", "nat"},
+		{"NatGateway", "NATGateway", "natGateway", "nat_gateway", "natgateway"},
+		{"NativeAuditFieldsIncluded", "NativeAuditFieldsIncluded", "nativeAuditFieldsIncluded", "native_audit_fields_included", "nativeauditfieldsincluded"},
+		{"NumberOfAmiToKeep", "NumberOfAMIToKeep", "numberOfAMIToKeep", "number_of_ami_to_keep", "numberofamitokeep"},
+		{"Package", "Package", "package_", "package_", "package"},
+		{"Param", "Param", "param", "param", "param"},
+		{"Ram", "RAM", "ram", "ram", "ram"},
+		{"RamdiskId", "RAMDiskID", "ramDiskID", "ram_disk_id", "ramdiskid"},
+		{"RamDiskId", "RAMDiskID", "ramDiskID", "ram_disk_id", "ramdiskid"},
+		{"RepositoryUriTest", "RepositoryURITest", "repositoryURITest", "repository_uri_test", "repositoryuritest"},
+		{"RequestedAmiVersion", "RequestedAMIVersion", "requestedAMIVersion", "requested_ami_version", "requestedamiversion"},
+		{"Sns", "SNS", "sns", "sns", "sns"},
+		{"Sqs", "SQS", "sqs", "sqs", "sqs"},
+		{"SriovNetSupport", "SRIOVNetSupport", "sriovNetSupport", "sriov_net_support", "sriovnetsupport"},
+		{"SSEKMSKeyID", "SSEKMSKeyID", "sseKMSKeyID", "sse_kms_key_id", "ssekmskeyid"},
+		{"UUID", "UUID", "uuid", "uuid", "uuid"},
+		{"Vlan", "VLAN", "vlan", "vlan", "vlan"},
+	}
+	for _, tc := range testCases {
+		n := names.New(tc.original)
+		msg := fmt.Sprintf("for original %s expected camel name of %s but got %s", tc.original, tc.expectCamel, n.Camel)
+		assert.Equal(tc.expectCamel, n.Camel, msg)
+		msg = fmt.Sprintf("for original %s expected lowercase camel name of %s but got %s", tc.original, tc.expectCamelLower, n.CamelLower)
+		assert.Equal(tc.expectCamelLower, n.CamelLower, msg)
+		msg = fmt.Sprintf("for original %s expected snake name of %s but got %s", tc.original, tc.expectSnake, n.Snake)
+		assert.Equal(tc.expectSnake, n.Snake, msg)
+		msg = fmt.Sprintf("for original %s expected snake stripped name of %s but got %s", tc.original, tc.expectSnakeStripped, n.SnakeStripped)
+		assert.Equal(tc.expectSnakeStripped, n.SnakeStripped, msg)
+	}
+}


### PR DESCRIPTION
Ports the `github.com/aws-controllers-k8s/code-generator/pkg/names`
package to the new repository, making one change to the package:
adding a `Names.SnakeStripped` field that contains the snake-cased
name stripped of any non-alphanumeric characters. This is useful for
determining the Go package name from a resource name...

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

Issue #, if available:

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
