### PR TITLE
fix NetworkConfiguration.AwsvpcConfiguration init

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -86,6 +86,14 @@ var (
 		{"Api", "API", "api", nil},
 		{"Arn", "ARN", "arn", nil},
 		{"Asn", "ASN", "asn", nil},
+		// eventbridge has a NetworkConfiguration.awsvpcConfiguration field for
+		// configuration of ECS tasks in "awsvpc" mode. aws-sdk-go transforms
+		// this to AwsvpcConfiguration in order to export the field name in
+		// Golang.
+		// (See https://github.com/aws/aws-sdk-go/blob/5707eba1610d563b9c563dbc862587649bcb9811/service/eventbridge/api.go#L13088)
+		// We need to prevent AwsvpcConfiguration from becoming
+		// AWSvpcConfiguration
+		{"Awsvpc", "AWSVPC", "awsVPC", nil},
 		{"Aws", "AWS", "aws", nil},
 		{"Az", "AZ", "az", nil},
 		{"Bgp", "BGP", "bgp", nil},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -39,6 +39,9 @@ func TestNames(t *testing.T) {
 		{"AwsVpcConfiguration", "AWSVPCConfiguration", "awsVPCConfiguration", "aws_vpc_configuration", "awsvpcconfiguration"},
 		{"AWSVpcConfiguration", "AWSVPCConfiguration", "awsVPCConfiguration", "aws_vpc_configuration", "awsvpcconfiguration"},
 		{"AWSVPCConfiguration", "AWSVPCConfiguration", "awsVPCConfiguration", "aws_vpc_configuration", "awsvpcconfiguration"},
+		// eventbridge has a NetworkConfiguration.AwsvpcConfiguration field for
+		// configuration of ECS tasks in "awsvpc" mode
+		{"AwsvpcConfiguration", "AWSVPCConfiguration", "awsVPCConfiguration", "aws_vpc_configuration", "awsvpcconfiguration"},
 		{"CacheSecurityGroup", "CacheSecurityGroup", "cacheSecurityGroup", "cache_security_group", "cachesecuritygroup"},
 		{"Camila", "Camila", "camila", "camila", "camila"},
 		{"DbInstanceId", "DBInstanceID", "dbInstanceID", "db_instance_id", "dbinstanceid"},


### PR DESCRIPTION
Pay attention to the specific capitalization of things in this PR...

The eventbridge API has a field called
`NetworkConfiguration.awsvpcConfiguration`:

https://github.com/aws/aws-sdk-go/blob/5707eba1610d563b9c563dbc862587649bcb9811/models/apis/eventbridge/2015-10-07/api-2.json#L2255

The **shape name** for this field is named `AwsVpcConfiguration`.

aws-sdk-go transforms the **field name** into `AwsvpcConfiguration` in order to meet Golang's exported field name requirements:

https://github.com/aws/aws-sdk-go/blob/5707eba1610d563b9c563dbc862587649bcb9811/service/eventbridge/api.go#L13088

However, Go variable/field names should capitalize acronyms and initialisms according to Go naming conventions:

https://github.com/golang/go/wiki/CodeReviewComments#initialisms

So, the field AND shape names should be `AWSVPCConfiguration`.

This patch ensures that the `awsvpcConfiguration` field name is properly transformed into `AWSVPCConfiguration` just like the shape name `AwsVpcConfiguration` is already transformed into `AWSVPCConfiguration`.

Confusing? Yes.

Closes Issue aws-controllers-k8s/community#1666

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
