### PR TITLE
fix secret camel case

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -109,7 +109,8 @@ var (
 		{"Dpd", "DPD", "dpd", nil},
 		{"Ebs", "EBS", "ebs", nil},
 		{"Ec2", "EC2", "ec2", nil},
-		{"Ecr", "ECR", "ecr", nil},
+		// Prevent "Secret" from becoming "s_ecr_et"
+		{"Ecr", "ECR", "ecr", re2.MustCompile("(?!S|s)ecr(?!et)", re2.None)},
 		{"Ecs", "ECS", "ecs", nil},
 		// Prevent "Edit" from becoming "EDIt"
 		{"Edi", "EDI", "edi", re2.MustCompile("Edi(?!t)", re2.None)},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -94,6 +94,7 @@ func TestNames(t *testing.T) {
 		{"RepositoryUriTest", "RepositoryURITest", "repositoryURITest", "repository_uri_test", "repositoryuritest"},
 		{"RequestedAmiVersion", "RequestedAMIVersion", "requestedAMIVersion", "requested_ami_version", "requestedamiversion"},
 		{"SaslScram512Auth", "SASLSCRAM512Auth", "saslSCRAM512Auth", "sasl_scram_512_auth", "saslscram512auth"},
+		{"Secret", "Secret", "secret", "secret", "secret"},
 		{"Sns", "SNS", "sns", "sns", "sns"},
 		{"Sql", "SQL", "sql", "sql", "sql"},
 		{"Sqs", "SQS", "sqs", "sqs", "sqs"},


### PR DESCRIPTION
Description of changes:
prevent `secret` from becoming `s_ecr_et`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
