### PR TITLE
Handle case insensitive sample of `TTL` in initialism

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -164,7 +164,7 @@ var (
 		{"Tde", "TDE", "tde", nil},
 		{"Tpm", "TPM", "tpm", nil},
 		{"Tls", "TLS", "tls", nil},
-		{"Ttl", "TTL", "ttl", re2.MustCompile("(?!Thro)ttl(?!ing|e)|(Ttl)", re2.None)},
+		{"Ttl", "TTL", "ttl", re2.MustCompile("(?!Thro)((?i)ttl)(?!ing|e)", re2.None)},
 		{"Udp", "UDP", "udp", nil},
 		// Need to prevent "security" from becoming "SecURIty"
 		{"Uri", "URI", "uri", re2.MustCompile("(?!sec)uri(?!ty)|(Uri)", re2.None)},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -103,6 +103,7 @@ func TestNames(t *testing.T) {
 		{"SriovNetSupport", "SRIOVNetSupport", "sriovNetSupport", "sriov_net_support", "sriovnetsupport"},
 		{"SSEKMSKeyID", "SSEKMSKeyID", "sseKMSKeyID", "sse_kms_key_id", "ssekmskeyid"},
 		{"Tpm", "TPM", "tpm", "tpm", "tpm"},
+		{"TTL", "TTL", "ttl", "ttl", "ttl"},
 		{"Throttle", "Throttle", "throttle", "throttle", "throttle"},
 		{"Throttling", "Throttling", "throttling", "throttling", "throttling"},
 		{"UUID", "UUID", "uuid", "uuid", "uuid"},


### PR DESCRIPTION
Fix https://github.com/aws-controllers-k8s/community/issues/1916

Description of changes:
- Handle case insensitive sample of `TTL` in initilism. Previous to this patch the `names` package used to transforms `TTL` and `ttl` cases into `tTL`.

Once ported to code-generator this will unblock https://github.com/aws-controllers-k8s/route53-controller/pull/31

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
