### PR TITLE
Add `MiBps` to initialism checkers

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -137,6 +137,7 @@ var (
 		{"Kms", "KMS", "kms", nil},
 		{"Ldap", "LDAP", "ldap", nil},
 		{"Mfa", "MFA", "mfa", nil},
+		{"Mibps", "MiBps", "miBps", re2.MustCompile("Mibps", re2.None)},
 		// Prevent "Native" from becoming "NATive"
 		{"Nat", "NAT", "nat", re2.MustCompile("Nat(?!i)", re2.None)},
 		// Prevent Oid from becoming oID and OIDC from becoming OIDc

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -108,6 +108,7 @@ func TestNames(t *testing.T) {
 		{"Throttling", "Throttling", "throttling", "throttling", "throttling"},
 		{"UUID", "UUID", "uuid", "uuid", "uuid"},
 		{"Vlan", "VLAN", "vlan", "vlan", "vlan"},
+		{"MiBps", "MiBps", "miBps", "mi_bps", "mibps"},
 		{"LastDecreaseDateTime", "LastDecreaseDateTime", "lastDecreaseDateTime", "last_decrease_date_time", "lastdecreasedatetime"},
 		{"NumberOfDecreasesToday", "NumberOfDecreasesToday", "numberOfDecreasesToday", "number_of_decreases_today", "numberofdecreasestoday"},
 	}


### PR DESCRIPTION
This is needed for efs-controller `ProvisionedThroughputInMiBps` field. Keeping camel case naming clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
