### PR TITLE
Add `GRPC` to initialism array

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -125,6 +125,7 @@ var (
 		{"Fpga", "FPGA", "fpga", nil},
 		{"Gid", "GID", "gid", nil},
 		{"Gpu", "GPU", "gpu", nil},
+		{"Grpc", "GRPC", "grpc", nil},
 		{"Html", "HTML", "html", nil},
 		{"Http", "HTTP", "http", nil},
 		{"Https", "HTTPS", "https", nil},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -94,6 +94,7 @@ func TestNames(t *testing.T) {
 		{"Uid", "UID", "uid", "uid", "uid"},
 		{"Uids", "UIDs", "uids", "uids", "uids"},
 		{"Gids", "GIDs", "gids", "gids", "gids"},
+		{"Grpc", "GRPC", "grpc", "grpc", "grpc"},
 		{"Ram", "RAM", "ram", "ram", "ram"},
 		{"RamdiskId", "RAMDiskID", "ramDiskID", "ram_disk_id", "ramdiskid"},
 		{"RamDiskId", "RAMDiskID", "ramDiskID", "ram_disk_id", "ramdiskid"},


### PR DESCRIPTION
This is needed for ELBv2 controller, `TargetGroup` resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
