### PR TITLE
Handle special cases for IPv4 and IPv6

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -73,6 +73,9 @@ var (
 		{"MD5Of", "MD5Of", "md5Of", re2.MustCompile("M[dD]5Of", re2.None)},
 		// Prevent IPC from becoming IPc (ECS Task definition field)
 		{"Ipc", "IPC", "ipc", re2.MustCompile("Ipc", re2.None)},
+		// Prevent IPv4 from becoming iPv4
+		{"IPv4", "IPv4", "ipv4", re2.MustCompile("I[Pp]v4", re2.None)},
+		{"IPv6", "IPv6", "ipv6", re2.MustCompile("I[Pp]v6", re2.None)},
 		// Prevent "MultipartUpload" from becoming "MultIPartUpload"
 		// and "IPAM" from becoming "IPam"
 		{"Ip", "IP", "ip", re2.MustCompile("Ip(?!art|am)", re2.None)},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -70,6 +70,13 @@ func TestNames(t *testing.T) {
 		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance", "ioperformance"},
 		{"Iops", "IOPS", "iops", "iops", "iops"},
 		{"Ip", "IP", "ip", "ip", "ip"},
+		// The ipv_4/ipv_6 is a special case mainly caused by github.com/iancoleman/strcase
+		// which does not handle this case correctly. See https://github.com/iancoleman/strcase/issues/22
+		// This is OK for now as snake case is only used for package names and not for field names.
+		{"IPv4", "IPv4", "ipv4", "ipv_4", "ipv4"},
+		{"Ipv4", "IPv4", "ipv4", "ipv_4", "ipv4"},
+		{"IPv6", "IPv6", "ipv6", "ipv_6", "ipv6"},
+		{"Ipv6", "IPv6", "ipv6", "ipv_6", "ipv6"},
 		{"Ipam", "IPAM", "ipam", "ipam", "ipam"},
 		{"Ipc", "IPC", "ipc", "ipc", "ipc"},
 		{"Frame", "Frame", "frame", "frame", "frame"},


### PR DESCRIPTION
This commit addresses the issue of `IPv4` and `IPv6` being incorrectly
converted to `iPv4` and `iPv6` respectively during the lower-casing
process. It adds new entries to the initialisms variable to ensure that
`IPv4` and `IPv6` are correctly preserved during the conversion phase.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
