### PR TITLE
Add `IPAddress` and `AIML` to name mappings

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -73,6 +73,8 @@ var (
 		{"MD5Of", "MD5Of", "md5Of", re2.MustCompile("M[dD]5Of", re2.None)},
 		// Prevent IPC from becoming IPc (ECS Task definition field)
 		{"Ipc", "IPC", "ipc", re2.MustCompile("Ipc", re2.None)},
+		// Prevent IPAddress from becoming iPAddress
+		{"IPAddress", "IPAddress", "ip_address", nil},
 		// Prevent IPv4 from becoming iPv4
 		{"IPv4", "IPv4", "ipv4", re2.MustCompile("I[Pp]v4", re2.None)},
 		{"IPv6", "IPv6", "ipv6", re2.MustCompile("I[Pp]v6", re2.None)},
@@ -86,6 +88,7 @@ var (
 		// Easy find-and-replacements...
 		{"Acl", "ACL", "acl", nil},
 		{"Acm", "ACM", "acm", nil},
+		{"AIML", "AIML", "aiml", nil},
 		{"Acp", "ACP", "acp", nil},
 		{"Api", "API", "api", nil},
 		{"Arn", "ARN", "arn", nil},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -32,6 +32,7 @@ func TestNames(t *testing.T) {
 		expectSnake         string
 		expectSnakeStripped string
 	}{
+		{"AIML", "AIML", "aiml", "aiml", "aiml"},
 		{"Ami", "AMI", "ami", "ami", "ami"},
 		{"Acm", "ACM", "acm", "acm", "acm"},
 		{"AmiLaunchIndex", "AMILaunchIndex", "amiLaunchIndex", "ami_launch_index", "amilaunchindex"},
@@ -69,6 +70,7 @@ func TestNames(t *testing.T) {
 		{"Identifier", "Identifier", "identifier", "identifier", "identifier"},
 		{"IoPerformance", "IOPerformance", "ioPerformance", "io_performance", "ioperformance"},
 		{"Iops", "IOPS", "iops", "iops", "iops"},
+		{"IPAddressType", "IPAddressType", "ipAddressType", "ip_address_type", "ipaddresstype"},
 		{"Ip", "IP", "ip", "ip", "ip"},
 		// The ipv_4/ipv_6 is a special case mainly caused by github.com/iancoleman/strcase
 		// which does not handle this case correctly. See https://github.com/iancoleman/strcase/issues/22


### PR DESCRIPTION
- Add `IPAddress` to prevent it from becoming `iPAddress`
- Add `AIML` to easy find-and-replacements
- Update test cases to cover new mappings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
