### PR TITLE
Fix HTTPSPort -> httpSPort

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -134,7 +134,8 @@ var (
 		{"Gpu", "GPU", "gpu", nil},
 		{"Grpc", "GRPC", "grpc", nil},
 		{"Html", "HTML", "html", nil},
-		{"Http", "HTTP", "http", nil},
+		// Prevent HTTPSPort from becoming httpSPort
+		{"Http", "HTTP", "http", re2.MustCompile("HTTP(?!s|S)", re2.None)},
 		{"Https", "HTTPS", "https", nil},
 		{"Iam", "IAM", "iam", nil},
 		{"Icmp", "ICMP", "icmp", nil},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -63,6 +63,8 @@ func TestNames(t *testing.T) {
 		{"Examine", "Examine", "examine", "examine", "examine"},
 		{"Family", "Family", "family", "family", "family"},
 		{"FifoTopic", "FIFOTopic", "fifoTopic", "fifo_topic", "fifotopic"},
+		{"HttpsPort", "HTTPSPort", "httpsPort", "https_port", "httpsport"},
+		{"HTTPSPort", "HTTPSPort", "httpsPort", "https_port", "httpsport"},
 		{"Id", "ID", "id", "id", "id"},
 		{"ID", "ID", "id", "id", "id"},
 		{"Idle", "Idle", "idle", "idle", "idle"},


### PR DESCRIPTION
Description of changes:
- Added regex check to prevent "HTTP" initialism from triggering on HTTPS. 
- Added test case for HTTPSPort -> httpsPort.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
