### PR TITLE
Fix ACM initialism regression for all-caps form

### DIFF
--- a/names/names.go
+++ b/names/names.go
@@ -89,9 +89,12 @@ var (
 		{"Ami", "AMI", "ami", re2.MustCompile("Ami", re2.None)},
 		// Easy find-and-replacements...
 		{"Acl", "ACL", "acl", nil},
-		// Prevent "AcmeEndpoint" from becoming "ACMeEndpoint" — "Acme" is
-		// the ACME protocol, not the ACM service abbreviation.
-		{"Acm", "ACM", "acm", re2.MustCompile("Acm(?!e)", re2.None)},
+		// Match both the camel-cased "Acm" and the all-caps "ACM" forms of the
+		// ACM initialism, but NOT "Acme"/"ACMe" — "Acme" is the ACME protocol,
+		// not the ACM service abbreviation. Matching "ACM" (all-caps) is
+		// required so fields like CloudFront's "ACMCertificateArn" still
+		// lower-prefix to "acmCertificateARN" rather than "aCMCertificateARN".
+		{"Acm", "ACM", "acm", re2.MustCompile("(?:Acm|ACM)(?!e)", re2.None)},
 		{"AIML", "AIML", "aiml", nil},
 		{"Acp", "ACP", "acp", nil},
 		{"Api", "API", "api", nil},

--- a/names/names_test.go
+++ b/names/names_test.go
@@ -39,6 +39,9 @@ func TestNames(t *testing.T) {
 		{"AcmeEndpoint", "AcmeEndpoint", "acmeEndpoint", "acme_endpoint", "acmeendpoint"},
 		{"AcmeExternalAccountBinding", "AcmeExternalAccountBinding", "acmeExternalAccountBinding", "acme_external_account_binding", "acmeexternalaccountbinding"},
 		{"AcmeDomainValidation", "AcmeDomainValidation", "acmeDomainValidation", "acme_domain_validation", "acmedomainvalidation"},
+		// CloudFront's ViewerCertificate.ACMCertificateArn must keep the ACM
+		// initialism when lower-prefixed (acmCertificateARN), not aCMCertificateARN.
+		{"ACMCertificateArn", "ACMCertificateARN", "acmCertificateARN", "acm_certificate_arn", "acmcertificatearn"},
 		{"AmiLaunchIndex", "AMILaunchIndex", "amiLaunchIndex", "ami_launch_index", "amilaunchindex"},
 		{"Amis", "AMIs", "amis", "amis", "amis"},
 		{"AmiType", "AMIType", "amiType", "ami_type", "amitype"},


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: PR #47 stopped "AcmeEndpoint" from mangling to "ACMeEndpoint" by giving the ACM initialism a regex ("Acm(?!e)"). That moved ACM onto the regex code path, which only matches the camel-cased "Acm" and never the all-caps "ACM". As a result fields like CloudFront's ACMCertificateArn lost their initialism handling and lower-prefixed to "aCMCertificateARN" instead of "acmCertificateARN" -- a breaking CRD change.

Match both the camel "Acm" and all-caps "ACM" forms while still excluding "Acme", and add a regression test for ACMCertificateArn.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
